### PR TITLE
Apply pastel red theme

### DIFF
--- a/app/src/main/java/kr/com/characin/codexexample/MainActivity.kt
+++ b/app/src/main/java/kr/com/characin/codexexample/MainActivity.kt
@@ -13,9 +13,11 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -52,7 +54,12 @@ fun MainScreen() {
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         topBar = {
-            CenterAlignedTopAppBar(title = { Text(text = "Toolbar") })
+            CenterAlignedTopAppBar(
+                title = { Text(text = "Toolbar") },
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primary
+                )
+            )
         },
         bottomBar = {
             NavigationBar {

--- a/app/src/main/java/kr/com/characin/codexexample/ui/theme/Color.kt
+++ b/app/src/main/java/kr/com/characin/codexexample/ui/theme/Color.kt
@@ -2,10 +2,10 @@ package kr.com.characin.codexexample.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
+val Purple80 = Color(0xFFFFC1C1)
+val PurpleGrey80 = Color(0xFFFFD6D6)
+val Pink80 = Color(0xFFFFE6E6)
 
-val Purple40 = Color(0xFF6650a4)
-val PurpleGrey40 = Color(0xFF625b71)
-val Pink40 = Color(0xFF7D5260)
+val Purple40 = Color(0xFFFF9A9A)
+val PurpleGrey40 = Color(0xFFFF7D7D)
+val Pink40 = Color(0xFFFFA3A3)

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="purple_200">#FFBB86FC</color>
-    <color name="purple_500">#FF6200EE</color>
-    <color name="purple_700">#FF3700B3</color>
-    <color name="teal_200">#FF03DAC5</color>
-    <color name="teal_700">#FF018786</color>
+    <color name="purple_200">#FFFFC1C1</color>
+    <color name="purple_500">#FFFF9A9A</color>
+    <color name="purple_700">#FFFF7D7D</color>
+    <color name="teal_200">#FFFFD6D6</color>
+    <color name="teal_700">#FFFFA3A3</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
 </resources>


### PR DESCRIPTION
## Summary
- apply pastel red shades to the Compose color scheme
- update colors.xml to the same pastel red palette
- set toolbar background color using MaterialTheme

## Testing
- `./gradlew build` *(fails: Unable to download Gradle due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684be76c6820832cb250c2df6c8cc58d